### PR TITLE
Fixes missing support for file names containing hyphens, closes #1

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -5,10 +5,11 @@ if (PHP_SAPI != 'cli') {
 }
 
 require_once "autoload.php";
-use \Convertio\Convertio;
-use \ConvertioCLI\Info;
-use \ConvertioCLI\CLIOptions;
-use \ConvertioCLI\FilesOutput;
+
+use Convertio\Convertio;
+use ConvertioCLI\CLIOptions;
+use ConvertioCLI\FilesOutput;
+use ConvertioCLI\Info;
 
 $CLIOptions = new CLIOptions($argv);
 
@@ -23,7 +24,7 @@ if ($CLIOptions->isShowVersion()) {
 $APIKey = $CLIOptions->getAPIKey();
 $OutFormat = $CLIOptions->getOutputFormat();
 $OutDir = $CLIOptions->getOutputDir();
-$Files = $CLIOptions->input_files;
+$Files = $CLIOptions->getInputFiles();
 
 if (empty($APIKey)) {
     Info::printError("No API Key provided");


### PR DESCRIPTION
* Uses PHP's getopt() to retrieve CLI options
* Replaces '/' with DIRECTORY_SEPARATOR constant
* Fixes trailing slash in output dir path
* Removes public member $free_values
* Changes visibility of members $args and $input_files to private
* Adds getter for input files